### PR TITLE
Change run script to use /bin/sh not bash

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Synopsis:
 # Automatically tests exercism's JS track solutions against corresponding test files.


### PR DESCRIPTION
There's no bash in the base container, but /bin/sh seems to be sufficient.