### PR TITLE
Always use the latest version of the local webserver tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,8 @@ RUN set -ex; \
   yarn cache clean;
 
 # static binary used for webhook when running in dev mode
-ARG webhook_version=0.6.0
 RUN curl -L -o /usr/local/bin/exercism_local_tooling_webserver \
-  https://github.com/exercism/local-tooling-webserver/releases/download/${webhook_version}/exercism_local_tooling_webserver
+  https://github.com/exercism/local-tooling-webserver/releases/latest/download/exercism_local_tooling_webserver
 RUN chmod +x /usr/local/bin/exercism_local_tooling_webserver
 
 USER appuser


### PR DESCRIPTION
We want to treat the master of the local webserver repo as always deployable. Whenever the test runners Dockerfiles get rebuilt they can then be bumped to the latest.