### PR TITLE
🤖 Update `.dockerignore` file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ Dockerfile
 dev.Dockerfile
 .appends
 .github
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ node_modules
 Dockerfile
 dev.Dockerfile
 .appends
+.github

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ node_modules
 ./run-in-docker.sh
 Dockerfile
 dev.Dockerfile
+.appends

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ dev.Dockerfile
 .appends
 .github
 .gitignore
+.gitattributes

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ dev.Dockerfile
 .github
 .gitignore
 .gitattributes
+.dockerignore


### PR DESCRIPTION
To help both speedup Docker builds _and_ prevent new containers being created when unrelated files changes, this PR adds some rules to the `.dockerignore` file (or add the file when it didn't exist).
See https://docs.docker.com/engine/reference/builder/#dockerignore-file for more information on `.dockerignore` files and what they do.

# Tracking issue

See https://github.com/exercism/exercism/issues/6113
